### PR TITLE
fix go package number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge AS mongodb-dumper
 
 RUN apk update
 RUN apk upgrade
-RUN apk add --update go=1.16.4-r0 gcc g++ vips-dev
+RUN apk add --update go=1.16.5-r0 gcc g++ vips-dev
 
 WORKDIR /bitclout/src
 


### PR DESCRIPTION
This PR fixes the following bug:
```
ERROR: unable to select packages:
  go-1.16.5-r0:
    breaks: world[go=1.16.4-r0]
```

The core repo also uses `go-1.16.5-r0`. I think that's where the issue comes from.